### PR TITLE
Replaced randomInt call with crypto-js

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -35,6 +35,7 @@
     "ts-loader": "^8.0.14"
   },
   "dependencies": {
+    "random-js": "^2.1.0",
     "tweetnacl": "^1.0.3"
   }
 }

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -1,4 +1,6 @@
-import { randomInt } from 'crypto';
+import { Random } from 'random-js';
+
+const random = new Random();
 
 /**
  * Checks to see if two Uint8Arrays have the same contents.
@@ -80,13 +82,10 @@ export default function takeNRandom<T>(n: number, elements: T[]): T[] {
     case 0:
       return [];
     case 1:
-      return [elements[randomInt(elements.length)]];
+      return [elements[random.integer(0, elements.length)]];
     default:
   }
-  const shuf: T[] = [...elements];
-  for (let i = shuf.length - 1; i > 0; i--) {
-    const j = randomInt(0, i + 1);
-    [shuf[i], shuf[j]] = [shuf[j], shuf[i]];
-  }
+
+  const shuf: T[] = random.shuffle([...elements]);
   return shuf.slice(0, n);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7044,6 +7044,11 @@ quick-lru@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
+random-js@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/random-js/-/random-js-2.1.0.tgz#0c03238b0a4f701f7a4c7303036ade3083d8ee14"
+  integrity sha512-CRUyWmnzmZBA7RZSVGq0xMqmgCyPPxbiKNLFA5ud7KenojVX2s7Gv+V7eB52beKTPGxWRnVZ7D/tCIgYJJ8vNQ==
+
 react-is@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz"


### PR DESCRIPTION
In react/webpack/whatever, the `crypto` polyfill doesn't provide a `randomInt` function. This PR replaces that call with `crypto-js`, which has support for this function regardless of the crypto backend.