### PR TITLE
Patched out constant-time functions

### DIFF
--- a/packages/shamir/package.json
+++ b/packages/shamir/package.json
@@ -32,8 +32,7 @@
   "dependencies": {
     "@spliterati/uint8": "^1.0.5",
     "@spliterati/utils": "^0.3.1",
-    "@types/node": "^14.14.20",
-    "constant-time-js": "https://github.com/soatok/constant-time-js.git#8e056b2"
+    "@types/node": "^14.14.20"
   },
   "devDependencies": {
     "@babel/helper-compilation-targets": "^7.12.5",

--- a/packages/shamir/src/shamir.ts
+++ b/packages/shamir/src/shamir.ts
@@ -1,8 +1,26 @@
 import { randomBytes } from 'crypto';
 import type { uint8 } from '@spliterati/uint8';
 import takeNRandom from '@spliterati/utils';
+// import { compare_ints, select_ints } from 'constant-time-js';
+/* Note: The packaging for `constant-time-js` is currently a bit problematic with this package setup, but I'm leaving
+these functions in for now so that, when fixed, we can just drop in the replacements.
+ */
+
 // eslint-disable-next-line camelcase
-import { compare_ints, select_ints } from 'constant-time-js';
+function compare_ints(a: number, b: number): number {
+  if (a === b) {
+    return 0;
+  }
+  if (a > b) {
+    return -1;
+  }
+  return 1;
+}
+
+// eslint-disable-next-line camelcase
+function select_ints(cond: number, a: number, b: number): number {
+  return (cond !== 0) ? a : b;
+}
 
 /**
  * Operations over a Galois field of 2^8


### PR DESCRIPTION
I've patched out the function contents for now, but have left their invocations in place. I'll sort out the packaging of `constant-time-js` shortly.

There's some issue with both webpack and the way that this package interacts with the typescript build environment.